### PR TITLE
fix: disconnect reason through message.content

### DIFF
--- a/src/socket-sockjs.js
+++ b/src/socket-sockjs.js
@@ -66,7 +66,7 @@ export default function (socketUrl, customData, _path, options) {
       socketProxy.emit('connect');
     } else if (message.type === 'LEAVE') {
       socket.close();
-      socketProxy.emit('disconnect', message.reason || 'server left');
+      socketProxy.emit('disconnect', message.content || 'server left');
     } else if (message.type === 'SESSION_CONFIRM') {
       socketProxy.emit('session_confirm', socketProxy.id);
     } else if (message.type === 'CHAT') {


### PR DESCRIPTION
**Proposed changes**:
- use message.content instead of .reason to be complient with stompJS

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
