### PR TITLE
feat: add widget event callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ set to `true` if you don't want to see the launcher.
 | `storage`              | `"local"`          | Specifies the storage location of the conversation state in the browser. `"session"` defines the state to be stored in the session storage. The session storage persists on reload of the page, and is cleared after the browser or tab is closed, or when `sessionStorage.clear()`is called. `"local"` defines the state to be stored in the local stoage. The local storage persists after the the browser is closed, and is cleared when the cookies of the browser are cleared, or when `localStorage.clear()`is called. |
 | `customComponent`      | `null`             | Custom component to be used with custom responses. E.g.: `customComponent={ (messageData) => (<div>Custom React component</div>)` }                                                                                                                                                                                                                                                                                                                                                                                          |
 
+| `onWidgetEvent`        | `{}`             | call custom code on a specific widget event ( onChatOpen, onChatClose, onChatHidden, onChatVisible )
+
 ### Additional Examples
 
 ##### `customMessageDelay`

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const plugin = {
         customMessageDelay={args.customMessageDelay}
         tooltipPayload={args.tooltipPayload}
         tooltipDelay={args.tooltipDelay}
+        onWidgetEvent={args.onWidgetEvent}
       />, document.querySelector(args.selector)
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,8 @@ const ConnectedWidget = forwardRef((props, ref) => {
     sock,
     storage,
     props.docViewer,
-    props.connectOn
+    props.connectOn,
+    props.onWidgetEvent
   );
   return (
     <Provider store={store}>
@@ -154,7 +155,13 @@ ConnectedWidget.propTypes = {
   showMessageDate: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   customMessageDelay: PropTypes.func,
   tooltipPayload: PropTypes.string,
-  tooltipDelay: PropTypes.number
+  tooltipDelay: PropTypes.number,
+  onWidgetEvent: PropTypes.shape({
+    onChatOpen: PropTypes.func,
+    onChatClose: PropTypes.func,
+    onChatVisible: PropTypes.func,
+    onChatHidden: PropTypes.func
+  })
 };
 
 ConnectedWidget.defaultProps = {
@@ -187,7 +194,13 @@ ConnectedWidget.defaultProps = {
     return delay;
   },
   tooltipPayload: null,
-  tooltipDelay: 500
+  tooltipDelay: 500,
+  onWidgetEvent: {
+    onChatOpen: () => {},
+    onChatClose: () => {},
+    onChatVisible: () => {},
+    onChatHidden: () => {}
+  }
 };
 
 export default ConnectedWidget;

--- a/src/store/reducers/behaviorReducer.js
+++ b/src/store/reducers/behaviorReducer.js
@@ -3,7 +3,13 @@ import { SESSION_NAME } from 'constants';
 import * as actionTypes from '../actions/actionTypes';
 import { getLocalSession, storeParamsTo } from './helper';
 
-export default function (inputTextFieldHint, connectingText, storage, docViewer = false) {
+export default function (
+  inputTextFieldHint,
+  connectingText,
+  storage,
+  docViewer = false,
+  onWidgetEvent
+) {
   const initialState = Map({
     connected: false,
     initialized: false,
@@ -25,21 +31,32 @@ export default function (inputTextFieldHint, connectingText, storage, docViewer 
     switch (action.type) {
       // Each change to the redux store's behavior Map gets recorded to storage
       case actionTypes.SHOW_CHAT: {
-        return storeParams(state.update('isChatVisible', isChatVisible => true));
+        onWidgetEvent.onChatVisisble();
+        return storeParams(state.update('isChatVisible', () => true));
       }
       case actionTypes.HIDE_CHAT: {
-        return storeParams(state.update('isChatVisible', isChatVisible => false));
+        onWidgetEvent.onChatHidden();
+        return storeParams(state.update('isChatVisible', () => false));
       }
       case actionTypes.TOGGLE_CHAT: {
+        if (state.get('isChatOpen', false)) {
+          onWidgetEvent.onChatClose();
+        } else {
+          onWidgetEvent.onChatOpen();
+        }
+
         return storeParams(state.update('isChatOpen', isChatOpen => !isChatOpen).set('unreadCount', 0));
       }
       case actionTypes.OPEN_CHAT: {
-        return storeParams(state.update('isChatOpen', isChatOpen => true).set('unreadCount', 0));
+        onWidgetEvent.onChatOpen();
+        return storeParams(state.update('isChatOpen', () => true).set('unreadCount', 0));
       }
       case actionTypes.CLOSE_CHAT: {
-        return storeParams(state.update('isChatOpen', isChatOpen => false));
+        onWidgetEvent.onChatClose();
+        return storeParams(state.update('isChatOpen', () => false));
       }
       case actionTypes.TOGGLE_FULLSCREEN: {
+        onWidgetEvent.onChatFullScreen();
         return storeParams(state.update('fullScreenMode', fullScreenMode => !fullScreenMode));
       }
       case actionTypes.TOGGLE_INPUT_DISABLED: {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -16,7 +16,9 @@ function initStore(
   connectingText,
   socket,
   storage,
-  docViewer = false
+  docViewer = false,
+  connectOn,
+  onWidgetEvent,
 ) {
   const customMiddleWare = store => next => (action) => {
     const session_id = getLocalSession(storage, SESSION_NAME)
@@ -88,7 +90,7 @@ function initStore(
     next(action);
   };
   const reducer = combineReducers({
-    behavior: behavior(hintText, connectingText, storage, docViewer),
+    behavior: behavior(hintText, connectingText, storage, docViewer, onWidgetEvent),
     messages: messages(storage),
     metadata: metadata(storage)
   });


### PR DESCRIPTION
**Proposed changes**:
- add widget event callback.. allows for DTM ( tagging ) or simply capture user's interactions with the widget.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the documentation
- [ ] updated the changelog
