### PR TITLE
Fixed Typo

### DIFF
--- a/src/store/reducers/behaviorReducer.js
+++ b/src/store/reducers/behaviorReducer.js
@@ -31,7 +31,7 @@ export default function (
     switch (action.type) {
       // Each change to the redux store's behavior Map gets recorded to storage
       case actionTypes.SHOW_CHAT: {
-        onWidgetEvent.onChatVisisble();
+        onWidgetEvent.onChatVisible();
         return storeParams(state.update('isChatVisible', () => true));
       }
       case actionTypes.HIDE_CHAT: {


### PR DESCRIPTION
Widget-Event-Name onChatVisible() had a typo which causes an error when chat gets visible

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [x ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
