### PR TITLE
refactor: change field name for the url in quickreplies

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
@@ -61,7 +61,7 @@ class QuickReply extends PureComponent {
                 return (
                   <a
                     key={index}
-                    href={reply.payload}
+                    href={reply.url}
                     target={linkTarget}
                     rel="noopener noreferrer"
                     className={'reply'}

--- a/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/test/index.test.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/test/index.test.js
@@ -21,7 +21,7 @@ describe('<QuickReply />', () => {
         type: 'web_url',
         content_type: 'text',
         title: 'google',
-        payload: 'http://www.google.ca'
+        url: 'http://www.google.ca'
       }
     ]
   });

--- a/src/components/Widget/test/metadataLinkTarget.test.js
+++ b/src/components/Widget/test/metadataLinkTarget.test.js
@@ -26,7 +26,7 @@ describe('link target', () => {
           type: 'web_url',
           content_type: 'text',
           title: 'google',
-          payload: 'http://www.google.ca'
+          url: 'http://www.google.ca'
         }
       ]
     } });


### PR DESCRIPTION
following the update of rasa addons use the field url for   quick replies of type weburl

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the tests of the functionality
- [ ] updated the documentation
- [ ] updated the changelog
