### PR TITLE
fix: quick replies after refresh

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
@@ -33,8 +33,8 @@ class QuickReply extends PureComponent {
       id
     } = this.props;
 
-    const payload = reply.payload;
-    const title = reply.title;
+    const payload = reply.get('payload');
+    const title = reply.get('title');
     chooseReply(payload, title, id);
     // this.props.changeInputFieldHint('Type a message...');
   }
@@ -57,16 +57,16 @@ class QuickReply extends PureComponent {
         {isLast && (
           <div className="replies">
             {message.get('quick_replies').map((reply, index) => {
-              if (reply.type === 'web_url') {
+              if (reply.get('type') === 'web_url') {
                 return (
                   <a
                     key={index}
-                    href={reply.url}
+                    href={reply.get('url')}
                     target={linkTarget}
                     rel="noopener noreferrer"
                     className={'reply'}
                   >
-                    {reply.title}
+                    {reply.get('title')}
                   </a>
                 );
               }
@@ -77,7 +77,7 @@ class QuickReply extends PureComponent {
                   className={'reply'}
                   onClick={() => this.handleClick(reply)}
                 >
-                  {reply.title}
+                  {reply.get('title')}
                 </div>
               );
             })}

--- a/src/store/reducers/helper.js
+++ b/src/store/reducers/helper.js
@@ -1,4 +1,4 @@
-import { Map, List } from 'immutable';
+import { Map, fromJS } from 'immutable';
 import { MESSAGES_TYPES, MESSAGE_SENDER, SESSION_NAME } from 'constants';
 
 import { Video, Image, Message, Snippet, QuickReply } from 'messagesComponents';
@@ -58,7 +58,7 @@ export function createQuickReply(quickReply, sender) {
     component: QuickReply,
     text: quickReply.text,
     hint: quickReply.hint || 'Select an option...',
-    quick_replies: List(quickReply.quick_replies),
+    quick_replies: fromJS(quickReply.quick_replies),
     sender,
     showAvatar: true,
     chosenReply: null,


### PR DESCRIPTION
quick relies were not displayed correctly after refresh

after a pull of the session they were comming back as a Immutable object

