### PR TITLE
feat(sockjs): session_confirm can contain props

### DIFF
--- a/src/socket-sockjs.js
+++ b/src/socket-sockjs.js
@@ -68,13 +68,12 @@ export default function (socketUrl, customData, _path, options) {
       socket.close();
       socketProxy.emit('disconnect', message.content || 'server left');
     } else if (message.type === 'SESSION_CONFIRM') {
-      socketProxy.emit('session_confirm', socketProxy.id);
+      const props = JSON.parse(message.content)
+      socketProxy.emit('session_confirm', {session_id: socketProxy.id, ...props});
     } else if (message.type === 'CHAT') {
       const agentMessage = JSON.parse(message.content);
       delete agentMessage.recipient_id;
       socketProxy.emit('bot_uttered', agentMessage);
-    } else if (message.type === 'SESSION_CONFIRM') {
-      socketProxy.emit('session_confirm', message.content);
     }
   };
 

--- a/src/socket-sockjs.js
+++ b/src/socket-sockjs.js
@@ -35,9 +35,11 @@ export default function (socketUrl, customData, _path, options) {
   });
 
   socketProxy.on('session_request', () => {
+    const authData = options.authData || null;
+
     send({
       type: 'SESSION_REQUEST',
-      content: JSON.stringify(options.authData || null),
+      content: JSON.stringify({authData, ...customData}),
       sender: 'client'
     });
   });

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,15 +1,7 @@
-// import io from 'socket.io-client';
 import socketio from './socket-socketio';
 import sockjs from './socket-sockjs';
 
 const PROTOCOLS = { socketio, sockjs };
-// export default function (socketUrl, customData, path) {
-//   const options = path ? { path } : {};
-//   const socket = io(socketUrl, options);
-//   socket.on('connect', () => {
-//     console.log(`connect:${socket.id}`);
-//     socket.customData = customData;
-//   });
 export default function (socketUrl, customData, path, protocol, protocolOptions) {
   protocol = protocol || 'socketio';
   const socketProtocol = PROTOCOLS[protocol];
@@ -19,18 +11,3 @@ export default function (socketUrl, customData, path, protocol, protocolOptions)
   }
   throw new Error(`Undefined socket protocol ${protocol}`);
 }
-
-//   socket.on('connect_error', (error) => {
-//     console.log(error);
-//   });
-
-//   socket.on('error', (error) => {
-//     console.log(error);
-//   });
-
-//   socket.on('disconnect', (reason) => {
-//     console.log(reason);
-//   });
-
-//   return socket;
-// };


### PR DESCRIPTION
**Proposed changes**:
- The SESSION_CONFIRM message on the SockJS driver can now contain props, and more closely mimics the Socket.io implementation

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
