### PR TITLE
refactor: add a default value for links targets

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
@@ -62,7 +62,7 @@ class QuickReply extends PureComponent {
                   <a
                     key={index}
                     href={reply.get('url')}
-                    target={linkTarget}
+                    target={linkTarget || '_blank'}
                     rel="noopener noreferrer"
                     className={'reply'}
                   >


### PR DESCRIPTION
correct behavior when the metadata is empty for quick replies, open the link in a new tab

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
