### PR TITLE
fix: message duplicate appearing as a tooltip when closing the chat

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -167,6 +167,7 @@ class Widget extends Component {
     this.delayedMessage = message;
     this.messageDelayTimeout = setTimeout(() => {
       this.dispatchMessage(message);
+      this.delayedMessage = null;
       dispatch(triggerMessageDelayed(false));
       this.onGoingMessageDelay = false;
       this.popLastMessage();


### PR DESCRIPTION
fix duplicate message appearing when closing the chat window

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
