### PR TITLE
Update style.scss

### DIFF
--- a/src/components/Widget/components/Conversation/components/Sender/style.scss
+++ b/src/components/Widget/components/Conversation/components/Sender/style.scss
@@ -13,7 +13,7 @@
   
   .#{$namespace}new-message {
     font-size: 1em;
-    width: 100%;
+    width: calc(100% - 40px); // padding-left (15px) + width (35px - 2 * 5px = 25px) = 40px
     border: 0;
     background-color: $grey-2;
     padding-left: 15px;


### PR DESCRIPTION
Fix overflow on Firefox.

<img width="227" alt="Screen Shot 2020-04-27 at 5 09 11 PM" src="https://user-images.githubusercontent.com/759578/80421707-e8d03b00-88aa-11ea-98d9-439e1812c7c2.png">