### PR TITLE
fix: allow session re-use by re-reading session_id from local storage

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -348,9 +348,11 @@ class Widget extends Component {
       dispatch(pullSession());
 
       // Request a session from server
-      const localId = this.getSessionId();
       socket.on('connect', () => {
+        const localId = this.getSessionId();
         socket.emit('session_request', { session_id: localId });
+        // eslint-disable-next-line no-console
+        console.log(`emit session_request with session_id:${localId}`);
       });
 
       // When session_confirm is received from the server:
@@ -368,6 +370,7 @@ class Widget extends Component {
         If the localId is null or different from the remote_id,
         start a new session.
         */
+        const localId = this.getSessionId();
         if (localId !== remoteId) {
           // storage.clear();
           // Store the received session_id to storage


### PR DESCRIPTION
**Proposed changes**:

Re-read `session_id` from local storage on socket `connect` and `session_confirm` to allow re-use of session. 

Before, the `session_id` was only read on widget initialization which means if the connection was lost and then re-established without re-initializing the component the `session_id`, wasn't reused.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
