### PR TITLE
refactor: carrousel card now have the height of the biggest one

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/components/Carousel/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Carousel/styles.scss
@@ -3,8 +3,8 @@
 
 .#{$namespace}carousel-container {
     // @include message-bubble($grey-2, #000);
-    max-height: 345px;
-    height: 345px;
+    //max-height: 345px;
+    min-height: 345px;
     overflow-x: hidden;
     overflow-y: hidden;
     white-space: nowrap;
@@ -12,11 +12,14 @@
     padding-right: 0;
     margin-top: 8px;
     position: relative;
+    display: flex;
 
     .#{$namespace}carousel-card {
         display: inline-block;
+        max-width: 220px;
         width: 220px;
-        height: 324px;
+        min-width: 220px;
+        min-height: 324px;
         margin: 3px 13px 3px 1px;
         box-shadow: 4px 2px 12px 1px rgba(0, 0, 0, 0.1);
         border-radius: 8px;
@@ -49,7 +52,6 @@
             margin: 0 9px 8px 9px;
             opacity: 0.5;
             font-size: 0.8em;
-            height: 5em;
             overflow: hidden;
             white-space: normal;
             line-height: initial;
@@ -59,9 +61,8 @@
         }
 
         .#{$namespace}carousel-buttons-container {
-            position: absolute;
+            margin-bottom: 1.5rem;
             width: 100%;
-            top: 210px;
             .#{$namespace}reply {
                 min-height: 21px;
                 margin: 5px 10px;

--- a/src/components/Widget/components/Conversation/components/Messages/components/Carousel/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Carousel/styles.scss
@@ -5,10 +5,11 @@
     // @include message-bubble($grey-2, #000);
     //max-height: 345px;
     min-height: 345px;
+    padding-bottom: 10px;
     overflow-x: hidden;
     overflow-y: hidden;
     white-space: nowrap;
-    padding-left: -12px;
+    padding-left: 5px;
     padding-right: 0;
     margin-top: 8px;
     position: relative;


### PR DESCRIPTION
**Proposed changes**:
- carrousel have a min height
- they can grow relatively to the subtible text
- all card have the height of the biggest one
fix : https://app.asana.com/0/1172906309462386/1175520137156625?utm_term=button&utm_source=Iterable&utm_medium=email&utm_campaign=fr_welcome
**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
