### PR TITLE
fix: styles when widget is full screen

### DIFF
--- a/src/components/Widget/components/Conversation/components/Header/style.scss
+++ b/src/components/Widget/components/Conversation/components/Header/style.scss
@@ -110,6 +110,11 @@
   .#{$namespace}loading {
     @include loading-fs;
   }
+  &.#{$namespace}widget-container{
+    .#{$namespace}conversation-container{
+    margin-bottom: 0px;
+}}
+  
 }
 
 @media screen and (max-width: 800px) {

--- a/src/components/Widget/components/Launcher/index.js
+++ b/src/components/Widget/components/Launcher/index.js
@@ -29,7 +29,6 @@ const Launcher = ({
 }) => {
   const className = ['rw-launcher'];
   if (isChatOpen) className.push('rw-hide-sm');
-  console.log(fullScreenMode);
   if (fullScreenMode && isChatOpen) className.push('rw-full-screen rw-hide');
 
 

--- a/src/components/Widget/components/Launcher/index.js
+++ b/src/components/Widget/components/Launcher/index.js
@@ -29,7 +29,8 @@ const Launcher = ({
 }) => {
   const className = ['rw-launcher'];
   if (isChatOpen) className.push('rw-hide-sm');
-  if (fullScreenMode) className.push(`rw-full-screen${isChatOpen ? '  rw-hide' : ''}`);
+  console.log(fullScreenMode);
+  if (fullScreenMode && isChatOpen) className.push('rw-full-screen rw-hide');
 
 
   const getComponentToRender = (message) => {


### PR DESCRIPTION
**Proposed changes**:
- closing the widget one in full screen broke the launcher styles
- there was a margin a the bottom when the widget was full screeen

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
