### PR TITLE
fix: page refresh when pressing on enter on firefox

### DIFF
--- a/src/components/Widget/components/Conversation/components/Sender/index.js
+++ b/src/components/Widget/components/Conversation/components/Sender/index.js
@@ -23,7 +23,7 @@ const Sender = ({ sendMessage, inputTextFieldHint, disabledInput, userInput }) =
       e.preventDefault();
       // by dispatching the event we trigger onSubmit
       // formRef.current.submit() would not trigger onSubmit
-      formRef.current.dispatchEvent(new Event('submit'));
+      formRef.current.dispatchEvent(new Event('submit', { cancelable: true }));
     }
   }
   return (


### PR DESCRIPTION
add { cancelable: true } to the submit event
chrome does not care about cancelable to cancel an event, firefox does

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
