### PR TITLE
docs: replace google storage link with jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In your `<body/>`:
 ```javascript
 <div id="webchat"/>
 <script src="https://cdn.jsdelivr.net/npm/rasa-webchat/lib/index.min.js"></script>
-// you can add a version tag if you need, e.g for version 11.5 https://cdn.jsdelivr.net/npm/rasa-webchat@0.11.5/lib/index.min.js
+// you can add a version tag if you need, e.g for version 0.11.5 https://cdn.jsdelivr.net/npm/rasa-webchat@0.11.5/lib/index.min.js
 <script>
   WebChat.default.init({
     selector: "#webchat",

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@
 In your `<body/>`:
 ```javascript
 <div id="webchat"/>
-<script src="https://storage.googleapis.com/mrbot-cdn/webchat-latest.js"></script>
-// Or you can replace latest with a specific version
+<script src="https://cdn.jsdelivr.net/npm/rasa-webchat/lib/index.min.js"></script>
+// you can add a version tag if you need, e.g for version 11.5 https://cdn.jsdelivr.net/npm/rasa-webchat@0.11.5/lib/index.min.js
 <script>
   WebChat.default.init({
     selector: "#webchat",


### PR DESCRIPTION
remplace google storage link with jsDelivr link

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
