### PR TITLE
feat: possibility to send a payload on tooltip close

### DIFF
--- a/src/components/Widget/components/Launcher/index.js
+++ b/src/components/Widget/components/Launcher/index.js
@@ -16,7 +16,7 @@ import openLauncher from 'assets/launcher_button.svg';
 import closeIcon from 'assets/clear-button-grey.svg';
 import close from 'assets/clear-button.svg';
 import Badge from './components/Badge';
-
+import { safeQuerySelectorAll } from 'utils/dom';
 import './style.scss';
 import ThemeContext from '../../ThemeContext';
 
@@ -42,7 +42,7 @@ const Launcher = ({
 
   useEffect(() => {
     const setReference = (selector) => {
-      const reference = document.querySelectorAll(selector);
+      const reference = safeQuerySelectorAll(selector)
       if (reference && reference.length === 1) {
         onRemove(reference[0], () => setReferenceElement(null));
         setReferenceElement(reference[0]);

--- a/src/components/Widget/components/Launcher/index.js
+++ b/src/components/Widget/components/Launcher/index.js
@@ -10,9 +10,8 @@ import 'slick-carousel/slick/slick-theme.css';
 
 import { MESSAGES_TYPES } from 'constants';
 import { Image, Message, Buttons } from 'messagesComponents';
-import { showTooltip as showTooltipAction } from 'actions';
+import { showTooltip as showTooltipAction, emitUserMessage} from 'actions';
 import { onRemove } from 'utils/dom';
-
 import openLauncher from 'assets/launcher_button.svg';
 import closeIcon from 'assets/clear-button-grey.svg';
 import close from 'assets/clear-button.svg';
@@ -34,7 +33,8 @@ const Launcher = ({
   lastMessages,
   closeTooltip,
   lastUserMessage,
-  domHighlight
+  domHighlight,
+  sendPayload
 }) => {
   const { mainColor, assistBackgoundColor } = useContext(ThemeContext);
 
@@ -121,6 +121,11 @@ const Launcher = ({
             /* stop the propagation because the popup is also a button
             otherwise it would open the webchat when closing the tooltip */
             e.stopPropagation();
+            
+            const payload = domHighlight.get('tooltipClose')
+              if(domHighlight && payload){
+                sendPayload(`/${payload}`)
+              }
             closeTooltip();
           }}
         >
@@ -252,7 +257,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  closeTooltip: () => dispatch(showTooltipAction(false))
+  closeTooltip: () => dispatch(showTooltipAction(false)),
+  sendPayload: (payload) => dispatch(emitUserMessage(payload))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Launcher);

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -33,7 +33,7 @@ import {
   evalUrl,
   setCustomCss
 } from 'actions';
-
+import { safeQuerySelectorAll } from 'utils/dom';
 import { SESSION_NAME, NEXT_MESSAGE } from 'constants';
 import { isVideo, isImage, isButtons, isText, isCarousel } from './msgProcessor';
 import WidgetLayout from './layout';
@@ -274,7 +274,7 @@ class Widget extends Component {
     const { domHighlight, defaultHighlightClassname } = this.props;
     const domHighlightJS = domHighlight.toJS() || {};
     if (domHighlightJS.selector) {
-      const elements = document.querySelectorAll(domHighlightJS.selector);
+      const elements = safeQuerySelectorAll(domHighlightJS.selector)
       elements.forEach((element) => {
         switch (domHighlightJS.style) {
           case 'custom':
@@ -298,7 +298,7 @@ class Widget extends Component {
     const { domHighlight, defaultHighlightCss, defaultHighlightClassname } = this.props;
     const domHighlightJS = domHighlight.toJS() || {};
     if (domHighlightJS.selector) {
-      const elements = document.querySelectorAll(domHighlightJS.selector);
+      const elements = safeQuerySelectorAll(domHighlightJS.selector)
       elements.forEach((element) => {
         switch (domHighlightJS.style) {
           case 'custom':

--- a/src/components/Widget/test/metadataStore.test.js
+++ b/src/components/Widget/test/metadataStore.test.js
@@ -131,7 +131,8 @@ describe('Messages metadata affect store', () => {
       metadata: {
         domHighlight: {
           selector: '.test',
-          style: 'color: red'
+          style: 'color: red',
+          tooltipClose: 'dummy'
         }
       }
     };
@@ -143,7 +144,8 @@ describe('Messages metadata affect store', () => {
     jest.runOnlyPendingTimers();
     expect(store.getState().metadata.get('domHighlight').toJS()).toEqual({
       selector: '.test',
-      style: 'color: red'
+      style: 'color: red',
+      tooltipClose: 'dummy'
     });
     // clear the dom highlight store so the next test does not try to remove it from the DOM
     store.dispatch({ type: 'SET_DOM_HIGHLIGHT',

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -14,3 +14,14 @@ export function onRemove(element, callback) {
     subtree: true
   });
 }
+
+
+export function safeQuerySelectorAll(selector) {
+  let elements
+  try {
+    elements = document.querySelectorAll(selector);
+  } catch (e) {
+    elements = []
+  }
+  return elements
+}


### PR DESCRIPTION
support a new metadata that allow for a payload to be sent when the tooltip is closed

goes with : https://github.com/botfront/botfront-ee/pull/193
**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
