### PR TITLE
fix contibuting project folder name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,12 @@ npm run build
 and then, add it to a dummy project using the file instead of the package. You can use either yarn or npm:
 
 ```bash
-npm i <path-to>/react-chat-widget
+npm i <path-to>/rasa-webchat
 
-yarn add file:<path-to>/react-chat-widget
+yarn add file:<path-to>/rasa-webchat
 ```
 
-##  Testing
+## Testing
 
 Your new feature **must** be tested with the proper tools. In this project, we use Jest and Enzyme. Once your tests are written, run:
 


### PR DESCRIPTION
**Proposed changes**:
- The default folder name in the installation step of the `contributing.md` file is wrong. When cloning the project the default project folder name is `rasa-webchat`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
