### PR TITLE
refactor: move message queue to the redux store

### DIFF
--- a/src/store/actions/actionTypes.js
+++ b/src/store/actions/actionTypes.js
@@ -36,4 +36,6 @@ export const SET_HINT_TEXT = 'SET_HINT_TEXT';
 export const SET_OLD_URL = 'SET_OLD_URL';
 export const EVAL_URL = 'EVAL_URL';
 export const SET_CUSTOM_CSS = 'SET_CUSTOM_CSS';
+export const ADD_MESSAGE_IN_QUEUE = 'ADD_MESSAGE_IN_QUEUE';
+export const SHIFT_MESSAGES_IN_QUEUE = 'SHIFT_MESSAGES_IN_QUEUE';
 

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -253,3 +253,17 @@ export function setCustomCss(customCss) {
   };
 }
 
+
+export function addMessageInQueue(message) {
+  return {
+    type: actions.ADD_MESSAGE_IN_QUEUE,
+    message
+  };
+}
+
+
+export function shiftMessagesInQueue() {
+  return {
+    type: actions.SHIFT_MESSAGES_IN_QUEUE
+  };
+}

--- a/src/store/reducers/behaviorReducer.js
+++ b/src/store/reducers/behaviorReducer.js
@@ -1,4 +1,4 @@
-import { Map, fromJS } from 'immutable';
+import { Map, fromJS, List } from 'immutable';
 import { SESSION_NAME } from 'constants';
 import * as actionTypes from '../actions/actionTypes';
 import { getLocalSession, storeParamsTo } from './helper';
@@ -20,7 +20,8 @@ export default function (
     unreadCount: 0,
     messageDelayed: false,
     oldUrl: '',
-    pageChangeCallbacks: Map()
+    pageChangeCallbacks: Map(),
+    messageQueue: List()
   });
 
   return function reducer(state = initialState, action) {
@@ -78,6 +79,12 @@ export default function (
       }
       case actionTypes.TRIGGER_MESSAGE_DELAY: {
         return storeParams(state.set('messageDelayed', action.messageDelayed));
+      }
+      case actionTypes.ADD_MESSAGE_IN_QUEUE: {
+        return storeParams(state.set('messageQueue', state.get('messageQueue').push(fromJS(action.message))));
+      }
+      case actionTypes.SHIFT_MESSAGES_IN_QUEUE: {
+        return storeParams(state.set('messageQueue', state.get('messageQueue').slice(1)));
       }
       case actionTypes.SET_OLD_URL: {
         return storeParams(state.set('oldUrl', action.url));


### PR DESCRIPTION
move message queue to the redux store so it does not get lost when leaving the page

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
